### PR TITLE
Add ReentrancyGuard & Tests

### DIFF
--- a/contracts/test/BadReentrant.sol
+++ b/contracts/test/BadReentrant.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.3;
+
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
+import "../DescendingPriceAuction.sol";
+
+// solhint-disable no-unused-vars
+contract BadReentrantERC20 is ERC20PresetMinterPauser {
+    bool private reEnterOnce = true;
+    address private immutable thief;
+
+    constructor(string memory _name, string memory _symbol)
+        ERC20PresetMinterPauser(_name, _symbol)
+    {
+        thief = _msgSender();
+    }
+
+    function transferFrom(
+        address,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        // sender doesnt even have to have tokens
+        _mint(recipient, amount);
+        // this can be done more than once...
+        if (reEnterOnce) {
+            reEnterOnce = false;
+            DescendingPriceAuction auctionContract =
+                DescendingPriceAuction(_msgSender());
+            uint256 latestAuctionId = auctionContract.totalAuctions();
+            auctionContract.bid(latestAuctionId);
+            IERC20 tokenWeStole =
+                IERC20(auctionContract.getAuction(latestAuctionId).tokens[0]);
+            tokenWeStole.transfer(thief, tokenWeStole.balanceOf(address(this)));
+            _burn(recipient, amount);
+        }
+        return true;
+    }
+}

--- a/contracts/test/DPAMock.sol
+++ b/contracts/test/DPAMock.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.3;
-pragma experimental ABIEncoderV2;
 
 import "../DescendingPriceAuction.sol";
 


### PR DESCRIPTION
Closes #11 

Adds reentrancyGuard and a test exploit. If you remove the nonReentrant modifier from bid(), then the test will fail. 

Exploit works by using a poisoned transferfrom which mints and burns payment tokens to bypass checks, and reenters the bid function once (but could do it several times) 